### PR TITLE
fix: align x402 resource middleware payload

### DIFF
--- a/x402-facilitator/src/middleware/x402-resource-server.ts
+++ b/x402-facilitator/src/middleware/x402-resource-server.ts
@@ -21,6 +21,10 @@ interface ResourceServerOptions {
  */
 export function x402PaymentRequired(options: ResourceServerOptions): MiddlewareHandler {
   const { facilitatorUrl, paymentRequirements, fetchFn = fetch } = options;
+  const serializedRequirements = {
+    ...paymentRequirements,
+    maxAmountRequired: paymentRequirements.maxAmountRequired.toString(),
+  };
 
   return async (c, next) => {
     const paymentHeader = c.req.header('x-402-payment');
@@ -53,7 +57,10 @@ export function x402PaymentRequired(options: ResourceServerOptions): MiddlewareH
       const verifyRes = await fetchFn(`${facilitatorUrl}/verify`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ payment, paymentRequirements }),
+        body: JSON.stringify({
+          paymentPayload: payment,
+          paymentRequirements: serializedRequirements,
+        }),
       });
 
       const verifyData = (await verifyRes.json()) as VerifyResponse;
@@ -66,7 +73,10 @@ export function x402PaymentRequired(options: ResourceServerOptions): MiddlewareH
       const settleRes = await fetchFn(`${facilitatorUrl}/settle`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ payment, paymentRequirements }),
+        body: JSON.stringify({
+          paymentPayload: payment,
+          paymentRequirements: serializedRequirements,
+        }),
       });
 
       const settleData = (await settleRes.json()) as SettleResponse;

--- a/x402-facilitator/tests/unit/x402-resource-server.test.ts
+++ b/x402-facilitator/tests/unit/x402-resource-server.test.ts
@@ -1,0 +1,77 @@
+import { Hono } from 'hono';
+import { describe, expect, it, vi } from 'vitest';
+
+import { x402PaymentRequired } from '../../src/middleware/x402-resource-server.js';
+
+const paymentRequirements = {
+  chainId: 8453 as const,
+  asset: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' as const,
+  payTo: '0x1111111111111111111111111111111111111111' as const,
+  maxAmountRequired: 20_000n,
+};
+
+const paymentPayload = {
+  x402Version: 1,
+  chainId: 8453,
+  asset: paymentRequirements.asset,
+  authorization: {
+    from: '0x2222222222222222222222222222222222222222',
+    to: paymentRequirements.payTo,
+    value: '20000',
+    validAfter: '0',
+    validBefore: '2000000000',
+    nonce: `0x${'01'.repeat(32)}`,
+  },
+  signature: `0x${'02'.repeat(65)}`,
+};
+
+describe('x402PaymentRequired', () => {
+  it('uses the facilitator route field names and serializes bigint requirements', async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          valid: true,
+          isValid: true,
+          payer: paymentPayload.authorization.from,
+        })),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          success: true,
+          txHash: `0x${'03'.repeat(32)}`,
+          transaction: `0x${'03'.repeat(32)}`,
+          network: 'base',
+          payer: paymentPayload.authorization.from,
+        })),
+      );
+
+    const app = new Hono();
+    app.use('/paid', x402PaymentRequired({
+      facilitatorUrl: 'https://facilitator.example',
+      paymentRequirements,
+      fetchFn,
+    }));
+    app.get('/paid', (c) => c.json({ ok: true }));
+
+    const response = await app.request('/paid', {
+      headers: {
+        'x-402-payment': Buffer.from(JSON.stringify(paymentPayload)).toString('base64'),
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+
+    for (const [, init] of fetchFn.mock.calls) {
+      expect(JSON.parse(init?.body as string)).toEqual({
+        paymentPayload,
+        paymentRequirements: {
+          ...paymentRequirements,
+          maxAmountRequired: '20000',
+        },
+      });
+    }
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes the opt-in x402 resource middleware so it can actually call this repository’s `/verify` and `/settle` routes:

- sends the route-required `paymentPayload` field instead of the unmatched `payment` field
- serializes `maxAmountRequired` from the internal `bigint` before JSON encoding
- adds a regression test covering verify → settle → downstream handler

This is intentionally limited to the facilitator boundary; it does not sign, settle, or change payment policy.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other

## Validation

- `vitest run`: 29 passed, 3 todo
- Typecheck is currently blocked by the existing undeclared `ioredis` dependency in `src/core/nonce-store.ts`.
- ESLint is currently blocked by the existing undeclared `@eslint/js` config dependency.

## Checklist

- [x] I’ve tested my changes
- [x] I’ve updated documentation if needed (not needed; wire contract only)
- [x] My code follows the project’s style guidelines

AI assistance was used to identify the field mismatch and draft the focused regression test; the diff and test results were manually verified.
